### PR TITLE
Clarify that we need a 'classic' GH token

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ options:
     default: ""
     type: string
   gh-token:
-    description: GitHub token to use. Required.
+    description: GitHub (classic) token to use - requires 'repo' access. Required.
     default: ""
     type: string
   gh-user:


### PR DESCRIPTION
Atlantis' docs aren't quite clear on this, but the token you create needs to be a "classic" token with `repo` access for GitHub.