### PR TITLE
Update contact in metadata to be a URL - new store requirement

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,7 +23,7 @@ description: |
   This charm is useful for teams wanting to automate their Terraform workflows.
 
 maintainers:
-  - launchpad.net/~canonical-is-devops
+  - https://launchpad.net/~canonical-is-devops
 issues: https://github.com/canonical/atlantis-operator/issues
 source: https://github.com/canonical/atlantis-operator
 assumes:


### PR DESCRIPTION
When uploading a charm, the store now requires all contact entries to be a URL (either `mailto:` or `http{,s}:`).